### PR TITLE
(log4net.Util.SystemStringFormat) MessageObject was serialized as {}

### DIFF
--- a/Log4ALA/LoggingEventSerializer.cs
+++ b/Log4ALA/LoggingEventSerializer.cs
@@ -70,7 +70,14 @@ namespace Log4ALA
                 }
                 else
                 {
-                    payload.Add(appender.coreFields.MiscMessageFieldName, loggingEvent.MessageObject);
+                    if (loggingEvent.MessageObject == null || loggingEvent.MessageObject is string || loggingEvent.MessageObject.GetType().FullName == "log4net.Util.SystemStringFormat")
+                    {
+                        payload.Add(appender.coreFields.MiscMessageFieldName, loggingEvent.RenderedMessage);
+                    }
+                    else
+                    {
+                        payload.Add(appender.coreFields.MiscMessageFieldName, loggingEvent.MessageObject);
+                    }
                 }
             }
 


### PR DESCRIPTION
When using log4net in a regular way i.e Log.Info("this is a text") the messageobject contains a log4net.Util.SystemStringFormat which gets serialized to {} by default.
This means no message body was sent to Azure Logging